### PR TITLE
Generate pdfs from sketchup help documentation

### DIFF
--- a/pdf_automation/pdf_automation/__main__.py
+++ b/pdf_automation/pdf_automation/__main__.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from .crawler import collect_internal_urls, render_urls_to_pdf
 
+# Optional: allow selecting Playwright backend via flag
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Crawl help.sketchup.com/en subtree and export pages to PDF.")
@@ -37,6 +39,15 @@ def main() -> None:
         default=None,
         help="Optional safety cap to limit number of pages crawled while testing.",
     )
+    parser.add_argument(
+        "--engine",
+        choices=["chrome", "playwright"],
+        default="chrome",
+        help="Rendering engine: built-in Chrome CLI or Playwright",
+    )
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--retries", type=int, default=2)
+    parser.add_argument("--timeout-ms", type=int, default=90_000)
 
     args = parser.parse_args()
 
@@ -55,13 +66,26 @@ def main() -> None:
     )
     print(f"Collected {len(urls)} URL(s) under allowed prefix.")
 
-    url_to_pdf = asyncio.run(
-        render_urls_to_pdf(
-            urls=sorted(urls),
-            output_root=args.output_root,
-            allowed_prefix=args.allowed_prefix,
+    if args.engine == "playwright":
+        from .playwright_main import render_urls_to_pdf_playwright
+        url_to_pdf = asyncio.run(
+            render_urls_to_pdf_playwright(
+                urls=sorted(urls),
+                output_root=args.output_root,
+                allowed_prefix=args.allowed_prefix,
+                concurrency=args.concurrency,
+                retries=args.retries,
+                timeout_ms=args.timeout_ms,
+            )
         )
-    )
+    else:
+        url_to_pdf = asyncio.run(
+            render_urls_to_pdf(
+                urls=sorted(urls),
+                output_root=args.output_root,
+                allowed_prefix=args.allowed_prefix,
+            )
+        )
     created = sum(1 for _u, p in url_to_pdf.items() if Path(p).exists())
     print(f"Rendered {created} PDF(s) to {args.output_root}")
 

--- a/pdf_automation/pdf_automation/playwright_main.py
+++ b/pdf_automation/pdf_automation/playwright_main.py
@@ -1,0 +1,131 @@
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+
+from .crawler import collect_internal_urls
+
+
+async def render_urls_to_pdf_playwright(urls: Iterable[str], output_root: str, allowed_prefix: str) -> Dict[str, str]:
+    """Render a collection of URLs to PDFs using Playwright (Chromium headless).
+
+    - Only renders URLs that start with the provided allowed_prefix
+    - Writes PDFs under output_root, mirroring the site path structure
+    """
+    from playwright.async_api import async_playwright  # lazy import to avoid hard dependency if unused
+
+    output_root_path = Path(output_root)
+    output_root_path.mkdir(parents=True, exist_ok=True)
+
+    url_to_pdf: Dict[str, str] = {}
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context()
+        for url in sorted(urls):
+            if not url.startswith(allowed_prefix):
+                continue
+            relative = url[len(allowed_prefix):].strip("/")
+            safe_relative = (relative or "index").replace("?", "_").replace("&", "_")
+            pdf_path = output_root_path / (safe_relative + ".pdf")
+            pdf_path.parent.mkdir(parents=True, exist_ok=True)
+
+            page = await context.new_page()
+            try:
+                await page.goto(url, wait_until="networkidle", timeout=90_000)
+                await page.emulate_media(media="screen")
+                await page.pdf(
+                    path=str(pdf_path),
+                    format="A4",
+                    print_background=True,
+                    margin={"top": "12mm", "bottom": "12mm", "left": "12mm", "right": "12mm"},
+                )
+            except Exception:
+                # Swallow errors to continue rendering the rest
+                pass
+            finally:
+                try:
+                    await page.close()
+                except Exception:
+                    pass
+
+            url_to_pdf[url] = str(pdf_path)
+
+        await context.close()
+        await browser.close()
+
+    return url_to_pdf
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Crawl help.sketchup.com/en subtree and export pages to PDF using Playwright (Chromium).",
+    )
+    parser.add_argument(
+        "--seed",
+        default="https://help.sketchup.com/en/3d-warehouse",
+        help="Seed URL to start crawling from (must be under https://help.sketchup.com/en/)",
+    )
+    parser.add_argument(
+        "--allowed-prefix",
+        default="https://help.sketchup.com/en/",
+        help="Only follow and render links that start with this prefix.",
+    )
+    parser.add_argument(
+        "--out",
+        dest="output_root",
+        default=str(Path("/workspace/pdf_automation/demo_output/help.sketchup.com/en").resolve()),
+        help="Output root directory for PDFs (subdirectories mirror site paths).",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=str(Path("/workspace/pdf_automation/demo_output/manifest.json").resolve()),
+        help="Path to manifest JSON mapping source URLs to generated PDF paths.",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=None,
+        help="Optional safety cap to limit number of pages crawled while testing.",
+    )
+
+    args = parser.parse_args()
+
+    if not args.seed.startswith(args.allowed_prefix):
+        raise SystemExit(
+            f"Seed URL must be under allowed prefix. Got seed={args.seed} allowed_prefix={args.allowed_prefix}"
+        )
+
+    urls = collect_internal_urls(
+        seed_url=args.seed,
+        allowed_prefix=args.allowed_prefix,
+        max_pages=args.max_pages,
+    )
+
+    url_to_pdf = asyncio.run(
+        render_urls_to_pdf_playwright(
+            urls=urls,
+            output_root=args.output_root,
+            allowed_prefix=args.allowed_prefix,
+        )
+    )
+
+    # Merge into or create manifest
+    manifest_path = Path(args.manifest)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {}
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text("utf-8"))
+        except Exception:
+            manifest = {}
+    manifest.update(url_to_pdf)
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Crawled {len(urls)} page(s). PDFs written to: {args.output_root}")
+    print(f"Manifest written: {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pdf_automation/pdf_automation/playwright_main.py
+++ b/pdf_automation/pdf_automation/playwright_main.py
@@ -1,56 +1,99 @@
 import argparse
 import asyncio
 import json
+import logging
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
 from .crawler import collect_internal_urls
 
 
-async def render_urls_to_pdf_playwright(urls: Iterable[str], output_root: str, allowed_prefix: str) -> Dict[str, str]:
+async def render_urls_to_pdf_playwright(
+    urls: Iterable[str],
+    output_root: str,
+    allowed_prefix: str,
+    *,
+    concurrency: int = 4,
+    retries: int = 2,
+    timeout_ms: int = 90_000,
+) -> Dict[str, str]:
     """Render a collection of URLs to PDFs using Playwright (Chromium headless).
 
     - Only renders URLs that start with the provided allowed_prefix
     - Writes PDFs under output_root, mirroring the site path structure
+    - Retries each URL a few times and logs progress
     """
     from playwright.async_api import async_playwright  # lazy import to avoid hard dependency if unused
 
+    log = logging.getLogger("playwright-pdf")
     output_root_path = Path(output_root)
     output_root_path.mkdir(parents=True, exist_ok=True)
 
     url_to_pdf: Dict[str, str] = {}
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        context = await browser.new_context()
-        for url in sorted(urls):
+        browser = await p.chromium.launch(headless=True, args=["--no-sandbox", "--disable-dev-shm-usage"]) 
+        context = await browser.new_context(
+            viewport={"width": 1280, "height": 2000},
+            user_agent=(
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+            ),
+            locale="en-US",
+        )
+
+        semaphore = asyncio.Semaphore(max(1, concurrency))
+
+        async def render_one(url: str) -> None:
             if not url.startswith(allowed_prefix):
-                continue
+                return
             relative = url[len(allowed_prefix):].strip("/")
             safe_relative = (relative or "index").replace("?", "_").replace("&", "_")
             pdf_path = output_root_path / (safe_relative + ".pdf")
             pdf_path.parent.mkdir(parents=True, exist_ok=True)
 
-            page = await context.new_page()
-            try:
-                await page.goto(url, wait_until="networkidle", timeout=90_000)
-                await page.emulate_media(media="screen")
-                await page.pdf(
-                    path=str(pdf_path),
-                    format="A4",
-                    print_background=True,
-                    margin={"top": "12mm", "bottom": "12mm", "left": "12mm", "right": "12mm"},
-                )
-            except Exception:
-                # Swallow errors to continue rendering the rest
-                pass
-            finally:
-                try:
-                    await page.close()
-                except Exception:
-                    pass
+            attempt = 0
+            while attempt <= retries:
+                attempt += 1
+                async with semaphore:
+                    page = await context.new_page()
+                    try:
+                        log.info("[%s/%s] %s", attempt, retries + 1, url)
+                        await page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
+                        # Let network settle and wait for common content containers if present
+                        try:
+                            await page.wait_for_load_state("networkidle", timeout=10_000)
+                        except Exception:
+                            pass
+                        try:
+                            await page.wait_for_selector("main, article, #main, .region-content, #content", timeout=5_000)
+                        except Exception:
+                            pass
 
+                        await page.emulate_media(media="screen")
+                        await page.pdf(
+                            path=str(pdf_path),
+                            format="A4",
+                            print_background=True,
+                            prefer_css_page_size=True,
+                            margin={"top": "12mm", "bottom": "12mm", "left": "12mm", "right": "12mm"},
+                        )
+                        if pdf_path.exists() and pdf_path.stat().st_size > 0:
+                            log.info("Saved %s", pdf_path)
+                            break
+                        else:
+                            log.warning("PDF not created yet for %s (attempt %s)", url, attempt)
+                    except Exception as e:
+                        log.warning("Render failed for %s (attempt %s): %s", url, attempt, e)
+                    finally:
+                        try:
+                            await page.close()
+                        except Exception:
+                            pass
             url_to_pdf[url] = str(pdf_path)
+
+        tasks: List[asyncio.Task] = [asyncio.create_task(render_one(u)) for u in sorted(urls)]
+        await asyncio.gather(*tasks)
 
         await context.close()
         await browser.close()
@@ -89,6 +132,9 @@ def main() -> None:
         default=None,
         help="Optional safety cap to limit number of pages crawled while testing.",
     )
+    parser.add_argument("--concurrency", type=int, default=4, help="Number of pages to render in parallel")
+    parser.add_argument("--retries", type=int, default=2, help="Retries per page if render fails")
+    parser.add_argument("--timeout-ms", type=int, default=90_000, help="Navigation timeout per page")
 
     args = parser.parse_args()
 
@@ -108,6 +154,9 @@ def main() -> None:
             urls=urls,
             output_root=args.output_root,
             allowed_prefix=args.allowed_prefix,
+            concurrency=args.concurrency,
+            retries=args.retries,
+            timeout_ms=args.timeout_ms,
         )
     )
 
@@ -122,7 +171,8 @@ def main() -> None:
             manifest = {}
     manifest.update(url_to_pdf)
     manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    print(f"Crawled {len(urls)} page(s). PDFs written to: {args.output_root}")
+    created = sum(1 for _u, p in url_to_pdf.items() if Path(p).exists() and Path(p).stat().st_size > 0)
+    print(f"Crawled {len(urls)} page(s). Created {created} PDF(s) at: {args.output_root}")
     print(f"Manifest written: {manifest_path}")
 
 

--- a/pdf_automation/requirements.txt
+++ b/pdf_automation/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.12.3
 requests==2.32.3
 weasyprint==61.2
 pydyf==0.10.0
+playwright==1.47.0


### PR DESCRIPTION
Add a Playwright-based script for crawling and generating PDFs of `help.sketchup.com` as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0c23fc3-0cda-4ec2-bd59-890ee0cf7d58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0c23fc3-0cda-4ec2-bd59-890ee0cf7d58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

