### PR TITLE
Crawl website for internal links

### DIFF
--- a/pdf_automation/crawler.py
+++ b/pdf_automation/crawler.py
@@ -1,6 +1,6 @@
 import os
 from collections import deque
-from typing import Dict, Iterable, Set, Tuple
+from typing import Dict, Iterable, Set, Tuple, Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -14,12 +14,14 @@ class SiteCrawler:
 	Builds a manifest of URL -> relative PDF path locations.
 	"""
 
-	def __init__(self, start_url: str, same_origin_only: bool = True, max_pages: int | None = None, allowed_prefix: str | None = None):
+	def __init__(self, start_url: str, same_origin_only: bool = True, max_pages: int | None = None, allowed_prefix: str | None = None, max_depth: int | None = None):
 		self.start_url = normalize_url(start_url, "")
 		self.same_origin_only = same_origin_only
 		self.max_pages = max_pages
 		# If provided, restrict accepted pages to this prefix (after redirects)
 		self.allowed_prefix = None if allowed_prefix is None else normalize_url(allowed_prefix, "")
+		# Optional maximum crawl depth (0 = only the start URL)
+		self.max_depth = max_depth
 
 	def _is_internal(self, base_url: str, target_url: str) -> bool:
 		if not self.same_origin_only:
@@ -38,18 +40,31 @@ class SiteCrawler:
 	def _is_allowed(self, url: str) -> bool:
 		if self.allowed_prefix is None:
 			return True
-		# accept if normalized URL starts with the allowed prefix
-		return url.startswith(self.allowed_prefix)
+		# Compare host and path to support "/en" and "/en/*" uniformly
+		from urllib.parse import urlparse
+		ap = urlparse(self.allowed_prefix)
+		tp = urlparse(url)
+		if (ap.scheme, ap.hostname) != (tp.scheme, tp.hostname):
+			return False
+		allowed_path = (ap.path or "/").rstrip("/")
+		path = tp.path or "/"
+		# Allow exact match ("/en") and descendants ("/en/..."), as well as root when allowed_path is "/"
+		if allowed_path == "/":
+			return True
+		return path == allowed_path or path.startswith(allowed_path + "/")
 
 	def crawl(self) -> Tuple[Dict[str, str], Dict[str, str]]:
 		"""Return (url->html, url->pdf_relpath) for discovered pages."""
 		seen: Set[str] = set()
+		queued: Set[str] = set()
 		html_by_url: Dict[str, str] = {}
 		pdf_rel_by_url: Dict[str, str] = {}
 
-		queue: deque[str] = deque([self.start_url])
+		# BFS queue holds (url, depth)
+		queue: deque[Tuple[str, int]] = deque([(self.start_url, 0)])
+		queued.add(self.start_url)
 		while queue:
-			url = queue.popleft()
+			url, depth = queue.popleft()
 			if url in seen:
 				continue
 			if self.max_pages is not None and len(seen) >= self.max_pages:
@@ -58,7 +73,7 @@ class SiteCrawler:
 			try:
 				resp = requests.get(url, timeout=20, allow_redirects=True)
 				resp.raise_for_status()
-				final_url = normalize_url(resp.url, "")
+			final_url = normalize_url(resp.url, "")
 				html = resp.text
 			except Exception:
 				continue
@@ -73,11 +88,15 @@ class SiteCrawler:
 			pdf_rel_by_url[final_url] = url_to_pdf_relpath(final_url)
 
 			soup = BeautifulSoup(html, "html.parser")
+			# If we've reached max_depth, do not enqueue children
+			if self.max_depth is not None and depth >= self.max_depth:
+				continue
 			for a in soup.find_all("a", href=True):
 				# Build absolute/normalized link relative to the final URL
 				target = normalize_url(final_url, a["href"])
-				if self._is_internal(self.start_url, target):
-					queue.append(target)
+				if self._is_internal(self.start_url, target) and target not in seen and target not in queued:
+					queue.append((target, depth + 1))
+					queued.add(target)
 
 		return html_by_url, pdf_rel_by_url
 


### PR DESCRIPTION
Implement max depth control, URL deduplication, and precise prefix matching in the crawler.

This prevents re-queueing of already discovered URLs, limits the crawl to a specified depth, and refines the `allowed_prefix` logic to correctly match paths like `/en` and `/en/*` without false positives.

---
<a href="https://cursor.com/background-agent?bcId=bc-671592b1-32d1-42c8-a4e6-e1f56ed3e165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-671592b1-32d1-42c8-a4e6-e1f56ed3e165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

